### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "data operations"
   ],
   "description": "Merge multiple classes with same shape to a single one",
-  "docker_image": "supervisely/data-operations:6.73.494",
+  "docker_image": "supervisely/data-operations:6.73.564",
   "instance_version": "6.15.40",
   "main_script": "src/merge_classes.py",
   "gui_template": "src/gui.html",

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "data operations"
   ],
   "description": "Merge multiple classes with same shape to a single one",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/merge_classes.py",
   "gui_template": "src/gui.html",

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "data operations"
   ],
   "description": "Merge multiple classes with same shape to a single one",
-  "docker_image": "supervisely/data-operations:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/merge_classes.py",
   "gui_template": "src/gui.html",

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
   ],
   "description": "Merge multiple classes with same shape to a single one",
   "docker_image": "supervisely/data-operations:6.73.564",
-  "instance_version": "6.15.40",
+  "instance_version": "6.15.60",
   "main_script": "src/merge_classes.py",
   "gui_template": "src/gui.html",
   "modal_template": "src/modal.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.182
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
